### PR TITLE
Make standalone embed pages transparent

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,7 @@
 @import url("https://fonts.googleapis.com/css2?family=Fraunces:wght@600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap");
 
 :root {
+  color-scheme: light;
   --bg-top: #fff4df;
   --bg-bottom: #f5fbff;
   --paper: rgba(255, 252, 247, 0.86);
@@ -62,6 +63,15 @@ body::after {
   width: 220px;
   height: 220px;
   background: rgba(255, 140, 105, 0.2);
+}
+
+body.notion-embed-page {
+  background: transparent;
+}
+
+body.notion-embed-page::before,
+body.notion-embed-page::after {
+  display: none;
 }
 
 .page-shell {
@@ -631,6 +641,45 @@ body::after {
 
 .single-demo-shell .board-column {
   order: 2;
+}
+
+body.notion-embed-page .page-shell {
+  width: min(1100px, calc(100vw - 8px));
+  padding: 8px 0 10px;
+}
+
+body.notion-embed-page .single-demo-grid {
+  margin-top: 0;
+}
+
+body.notion-embed-page .panel {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  backdrop-filter: none;
+  padding: 0;
+  overflow: visible;
+}
+
+body.notion-embed-page .panel::before,
+body.notion-embed-page .hero,
+body.notion-embed-page .panel-head {
+  display: none;
+}
+
+body.notion-embed-page .playground {
+  margin-top: 0;
+  gap: 14px;
+}
+
+body.notion-embed-page .single-demo-shell .playground {
+  grid-template-columns: minmax(320px, 0.95fr) minmax(0, 1.05fr);
+}
+
+body.notion-embed-page .status-card,
+body.notion-embed-page .mini-card {
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: none;
 }
 
 .hero-compact {

--- a/sudoku.html
+++ b/sudoku.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="light dark">
     <title>Sudoku | Pocket Solver Garden</title>
     <meta
       name="description"
@@ -10,23 +11,8 @@
     >
     <link rel="stylesheet" href="styles.css">
   </head>
-  <body>
+  <body class="notion-embed-page">
     <main class="page-shell single-demo-shell">
-      <section class="hero hero-compact">
-        <p class="eyebrow">Standalone embed</p>
-        <h1>Sudoku</h1>
-        <p class="lede">
-          A single-demo page built for Notion embeds: browser-side WASM solve,
-          custom puzzles, and a scrollable readable log.
-        </p>
-        <div class="pill-row">
-          <span class="pill">Browser-side WebAssembly</span>
-          <span class="pill">Bring your own puzzle</span>
-          <span class="pill">Trace stays local</span>
-          <a class="button button-secondary button-link" href="index.html">Back to gallery</a>
-        </div>
-      </section>
-
       <section class="single-demo-grid" aria-label="sudoku demo">
         <article class="panel panel-mint">
           <div class="panel-head">

--- a/tic-tac-toe.html
+++ b/tic-tac-toe.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="light dark">
     <title>Tic-tac-toe | Pocket Solver Garden</title>
     <meta
       name="description"
@@ -10,23 +11,8 @@
     >
     <link rel="stylesheet" href="styles.css">
   </head>
-  <body>
+  <body class="notion-embed-page">
     <main class="page-shell single-demo-shell">
-      <section class="hero hero-compact">
-        <p class="eyebrow">Standalone embed</p>
-        <h1>Tic-tac-toe</h1>
-        <p class="lede">
-          A single-demo page built for Notion embeds: local transformer weights,
-          explicit tool call, and a readable move trace.
-        </p>
-        <div class="pill-row">
-          <span class="pill">Local model weights</span>
-          <span class="pill">Transformers.js</span>
-          <span class="pill">ONNX in browser</span>
-          <a class="button button-secondary button-link" href="index.html">Back to gallery</a>
-        </div>
-      </section>
-
       <section class="single-demo-grid" aria-label="tic-tac-toe demo">
         <article class="panel panel-coral">
           <div class="panel-head">


### PR DESCRIPTION
## Summary
- remove the decorative shell from standalone embed pages
- make the standalone Tic-tac-toe and Sudoku pages transparent for Notion
- keep only the demo cards visible so the Notion page background shows through

## Verification
- manual HTML/CSS sanity pass on tic-tac-toe.html, sudoku.html, and styles.css