### PR TITLE
Improve Tally weak-label parser coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ There is now an adversarial harness for that exact gap:
 
 - `node scripts/evaluate_tally_harness.mjs`
 - reports candidate recall, top-1 accuracy, instability, and line-item recall by failure class
-- useful classes today: `candidate_missing`, `layout_drift`, `ocr_corruption`, `numeric_ambiguity`, `ranking_ambiguity`, `structural_inconsistency`
+- useful classes today: `candidate_missing`, `implicit_field`, `layout_drift`, `ocr_corruption`, `numeric_ambiguity`, `ranking_ambiguity`, `structural_inconsistency`
 
 ## Local development
 

--- a/tally/README.md
+++ b/tally/README.md
@@ -67,6 +67,7 @@ Pipeline:
    - optional industry extensions for pharma, medical, trading, and stockist flows
 4. Generate legal candidates for each field.
    - nearby label/value spans
+   - weak-label and implicit header spans like `#7782`, `Client`, `Supply:`, and `Final Amount`
    - GSTINs, dates, invoice numbers, totals
    - row-aware table parsing for line items, including multiline descriptions and common industry columns
 5. Rank and select candidates.
@@ -153,6 +154,7 @@ The harness is organized by failure class instead of document type:
 - `numeric_ambiguity`
 - `ocr_corruption`
 - `layout_drift`
+- `implicit_field`
 
 This is the current intended regression surface for parser work. If candidate recall is low, model changes should not be the first response.
 

--- a/tally/demo-samples.mjs
+++ b/tally/demo-samples.mjs
@@ -64,6 +64,34 @@ Zodiac Energy Ltd
 `.trim(),
   },
   {
+    id: "implicit-sales-core",
+    label: "Implicit Labels",
+    description:
+      "A weak-label sales invoice where invoice number, date, buyer, and total are present but not written in standard Tally-style labels.",
+    format: "text",
+    familyOverride: "auto",
+    industryOverride: "auto",
+    source: `
+#7782      11/07/25
+
+KAPOOR & SONS
+24ABCDE1111F1Z3
+
+Client:
+R K ENTERPRISES
+24AAAAA2222G1Z4
+
+Supply: Gujarat
+
+Item        Qty   Price   Total
+Tiles       200   50      10000
+
+Tax 18%              1800
+
+Final Amount         11800
+`.trim(),
+  },
+  {
     id: "account-statement",
     label: "Account Statement",
     description:

--- a/tally/export_field_dataset.mjs
+++ b/tally/export_field_dataset.mjs
@@ -117,6 +117,19 @@ const SEED_PRESET_EXPECTED = Object.freeze({
       "amounts.grand_total_cents": 16576000,
     },
   },
+  "implicit-sales-core": {
+    familyId: "sales_invoice",
+    fields: {
+      "document.number": "7782",
+      "document.date": "11/07/25",
+      "document.place_of_supply": "Gujarat",
+      "seller.name": "KAPOOR & SONS",
+      "seller.gstin": "24ABCDE1111F1Z3",
+      "buyer.name": "R K ENTERPRISES",
+      "buyer.gstin": "24AAAAA2222G1Z4",
+      "amounts.grand_total_cents": 1180000,
+    },
+  },
 });
 
 function parseArgs(argv) {

--- a/tally/harness.mjs
+++ b/tally/harness.mjs
@@ -38,6 +38,11 @@ export const TALLY_HARNESS_FAILURE_CLASSES = Object.freeze({
     label: "Layout Drift",
     description: "Blocks and rows are reordered or wrapped in ways that drift from the training templates.",
   },
+  implicit_field: {
+    id: "implicit_field",
+    label: "Implicit Field",
+    description: "Key fields exist but only under weak labels, shorthand headers, or unlabeled structure.",
+  },
 });
 
 const FIELD_MARGIN_THRESHOLD = 6;
@@ -117,6 +122,36 @@ const BASE_CASES = Object.freeze([
         unit: "nos",
         unitPriceCents: 2960000,
         amountCents: 14800000,
+      },
+    ],
+  },
+]);
+
+const EXPLICIT_FAILURE_CASES = Object.freeze([
+  {
+    id: "implicit-field-shorthand-sales",
+    presetId: "implicit-sales-core",
+    label: "Implicit Field / Shorthand Sales",
+    failureClass: "implicit_field",
+    variant: "shorthand_header",
+    voucherFamily: "sales_invoice",
+    shouldSupport: true,
+    fields: {
+      "document.number": "7782",
+      "document.date": "11/07/25",
+      "document.place_of_supply": "Gujarat",
+      "seller.name": "KAPOOR & SONS",
+      "seller.gstin": "24ABCDE1111F1Z3",
+      "buyer.name": "R K ENTERPRISES",
+      "buyer.gstin": "24AAAAA2222G1Z4",
+      "amounts.grand_total_cents": 1180000,
+    },
+    lineItems: [
+      {
+        description: "Tiles",
+        quantity: 200,
+        unitPriceCents: 5000,
+        amountCents: 1000000,
       },
     ],
   },
@@ -428,6 +463,22 @@ export function buildTallyAdversarialHarness(options = {}) {
     );
   });
 
+  for (const failureCase of EXPLICIT_FAILURE_CASES) {
+    const preset = getPresetById(failureCase.presetId);
+    cases.push({
+      id: failureCase.id,
+      label: failureCase.label,
+      baseCaseId: failureCase.presetId,
+      failureClass: failureCase.failureClass,
+      variant: failureCase.variant,
+      source: preset.source,
+      voucherFamily: failureCase.voucherFamily,
+      shouldSupport: failureCase.shouldSupport,
+      fields: { ...failureCase.fields },
+      lineItems: failureCase.lineItems.map((item) => ({ ...item })),
+    });
+  }
+
   return cases;
 }
 
@@ -635,4 +686,3 @@ export function evaluateTallyAdversarialHarness(options = {}) {
     },
   };
 }
-

--- a/tally/harness.test.mjs
+++ b/tally/harness.test.mjs
@@ -38,14 +38,25 @@ test("baseline harness controls still evaluate as supported with field recall", 
   assert.equal(report.lineItemSummary.candidateRecall.rate, 1);
 });
 
+test("implicit-field harness case keeps the weak-label values in the legal candidate set", () => {
+  const cases = buildTallyAdversarialHarness({ seed: 31, includeBaseline: true });
+  const implicitCase = cases.find((entry) => entry.id === "implicit-field-shorthand-sales");
+  assert.ok(implicitCase);
+
+  const report = evaluateTallyHarnessCase(implicitCase);
+  assert.equal(report.familyMatch, true);
+  assert.equal(report.scalarSummary.candidateRecall.rate, 1);
+  assert.equal(report.lineItemSummary.candidateRecall.rate, 1);
+});
+
 test("harness evaluation returns aggregate metrics by failure class", () => {
   const evaluation = evaluateTallyAdversarialHarness({ seed: 31, includeBaseline: true });
 
   assert.ok(evaluation.summary.caseCount >= 14);
   assert.ok("candidate_missing" in evaluation.summary.byFailureClass);
+  assert.ok("implicit_field" in evaluation.summary.byFailureClass);
   assert.ok("ocr_corruption" in evaluation.summary.byFailureClass);
   assert.ok("layout_drift" in evaluation.summary.byFailureClass);
   assert.ok(typeof evaluation.summary.byFailureClass.candidate_missing.scalarCandidateRecall === "number");
   assert.ok(Array.isArray(evaluation.caseReports));
 });
-

--- a/tally/model.test.mjs
+++ b/tally/model.test.mjs
@@ -84,3 +84,22 @@ test("model selection logic preserves explicit statement rejection", () => {
   assert.equal(record.voucherFamily, "account_statement");
   assert.match(record.rejectionReason ?? "", /ledger-oriented PSVM/i);
 });
+
+test("model selection logic can align the implicit weak-label sample", () => {
+  const state = buildTallyExtractionState(getPreset("implicit-sales-core").source);
+  const selection = buildSelectionFromExpectedValues(state, {
+    "document.number": "7782",
+    "document.date": "11/07/25",
+    "seller.name": "KAPOOR & SONS",
+    "buyer.name": "R K ENTERPRISES",
+    "amounts.grand_total_cents": 1180000,
+  });
+  const record = buildTallyRecord(state, selection.selectedFields);
+
+  assert.equal(record.voucherFamily, "sales_invoice");
+  assert.equal(record.document.number, "7782");
+  assert.equal(record.document.date, "11/07/25");
+  assert.equal(record.seller.name, "KAPOOR & SONS");
+  assert.equal(record.buyer.name, "R K ENTERPRISES");
+  assert.equal(record.amounts.grandTotalCents, 1180000);
+});

--- a/tally/psvm.mjs
+++ b/tally/psvm.mjs
@@ -8,18 +8,31 @@ const GSTIN_PATTERN = /\b\d{2}[A-Z]{5}\d{4}[A-Z][0-9A-Z]Z[0-9A-Z]\b/g;
 const GSTIN_VALUE_PATTERN = /\b\d{2}[A-Z]{5}\d{4}[A-Z][0-9A-Z]Z[0-9A-Z]\b/;
 const DATE_VALUE_PATTERN =
   /^(?:\d{1,2}\/\d{1,2}\/\d{2,4}|\d{1,2}-[A-Za-z]{3}-\d{2,4}|\d{1,2}\s+[A-Za-z]{3,9}\s+\d{2,4})$/;
+const INLINE_DATE_PATTERN =
+  /\b(?:\d{1,2}\/\d{1,2}\/\d{2,4}|\d{1,2}-[A-Za-z]{3}-\d{2,4}|\d{1,2}\s+[A-Za-z]{3,9}\s+\d{2,4})\b/i;
 const COMPANY_SUFFIX_PATTERN = /\b(?:LLP|LTD\.?|LIMITED|PRIVATE LIMITED|PVT\.?\s+LTD\.?)\b/i;
 const MONEY_TOKEN_PATTERN = /(?:₹\s*)?(?:Rs\.?\s*)?[0-9][0-9,]*\.\d{2}/;
+const LOOSE_MONEY_TOKEN_PATTERN = /(?:₹\s*)?(?:Rs\.?\s*)?[0-9][0-9,]*(?:\.\d{1,2})?/;
 const PARTY_HEADING_PATTERN =
-  /\b(?:buyer|bill to|sold to|consignee|ship to|supplier|seller|from)\b/i;
+  /\b(?:buyer|bill to|sold to|consignee|ship to|supplier|seller|from|client|customer|vendor)\b/i;
 const PARTY_METADATA_PATTERN =
-  /\b(?:gstin|gst no|uin|invoice|date|ack|e-way|amount|total|subtotal|tax|place of supply|state|phone|email|bank|branch|declaration)\b/i;
+  /\b(?:gstin|gst no|uin|invoice|date|ack|e-way|amount|total|subtotal|tax|place of supply|state|supply|phone|email|bank|branch|declaration)\b/i;
 const STATEMENT_HEADER_PATTERN =
   /\b(?:account statement|bank statement|statement of account|mini statement|ledger statement)\b/i;
 const STATEMENT_BALANCE_PATTERN =
   /\b(?:opening balance|closing balance|available balance|ledger balance|running balance)\b/i;
 const STATEMENT_COLUMN_PATTERN =
   /\b(?:debit|credit|withdrawal|deposit|narration|transaction|txn|cheque|utr|imps|neft|upi|balance)\b/i;
+const DOCUMENT_NUMBER_HASH_PATTERN = /#\s*([A-Z0-9][A-Z0-9/-]{0,39})\b/i;
+const GRAND_TOTAL_CUE_PATTERN =
+  /\b(?:grand\s*total|final amount|net amount|net payable|amount due|amount payable|balance due|total(?:\s+amount)?)\b/i;
+const SUBTOTAL_CUE_PATTERN = /\bsub\s*total\b/i;
+const TAXABLE_CUE_PATTERN = /\btaxable\b/i;
+const DISCOUNT_CUE_PATTERN = /\b(?:discount|disc\.?)\b/i;
+const ROUND_OFF_CUE_PATTERN = /\bround\s*off\b/i;
+const TAX_LINE_CUE_PATTERN = /\b(?:igst|cgst|sgst|cess|tax(?:\s+\d+(?:\.\d+)?%)?)\b/i;
+const TABLE_LINE_CUE_PATTERN =
+  /\b(?:item|description|goods|qty|quantity|rate|price|hsn|sac|amount|gross|units?)\b/i;
 const UNKNOWN_FAMILY_THRESHOLD = 1;
 
 export const TALLY_EXTRACTION_PSVM_OPS = Object.freeze([
@@ -130,14 +143,44 @@ function countPatternMatches(text, pattern) {
   return [...text.matchAll(regex)].length;
 }
 
+function parseLooseMoneyToCents(value) {
+  const text = String(value ?? "").trim();
+  if (!text) {
+    return null;
+  }
+
+  const normalized = text
+    .replace(/^Rs\.?\s*/i, "")
+    .replace(/₹/g, "")
+    .replace(/,/g, "")
+    .replace(/\s+/g, "");
+
+  if (!/^\d+(?:\.\d{1,2})?$/.test(normalized)) {
+    return null;
+  }
+
+  const [whole, fraction = ""] = normalized.split(".");
+  return Number(whole) * 100 + Number(fraction.padEnd(2, "0"));
+}
+
+function normalizeDocumentNumberValue(value) {
+  return cleanFieldCandidate(value).replace(/^#\s*/, "").replace(/[.:]+$/, "");
+}
+
+function extractInlineDate(value) {
+  const match = String(value ?? "").match(INLINE_DATE_PATTERN);
+  return match?.[0] ?? null;
+}
+
 function findHeadingRole(line) {
-  if (/\b(?:consignee|ship to)\b/i.test(line)) {
+  const text = collapseWhitespace(line);
+  if (/^(?:consignee|ship to)\b/i.test(text)) {
     return "consignee";
   }
-  if (/\b(?:buyer|bill to|sold to)\b/i.test(line)) {
+  if (/^(?:buyer|bill to|sold to|client|customer|party)\b/i.test(text)) {
     return "buyer";
   }
-  if (/\b(?:supplier|seller|from)\b/i.test(line)) {
+  if (/^(?:supplier|seller|from|vendor)\b/i.test(text)) {
     return "seller";
   }
   return null;
@@ -204,6 +247,30 @@ function isLikelyPartyName(line) {
   return /[A-Za-z]{2}/.test(text);
 }
 
+function findNearbyPartyName(lines, lineIndex) {
+  const offsets = [-1, 1, -2, 2];
+
+  for (const offset of offsets) {
+    const candidateIndex = lineIndex + offset;
+    if (candidateIndex < 0 || candidateIndex >= lines.length) {
+      continue;
+    }
+
+    const text = collapseWhitespace(lines[candidateIndex]);
+    if (!isLikelyPartyName(text)) {
+      continue;
+    }
+
+    return {
+      lineIndex: candidateIndex,
+      text,
+      distance: Math.abs(offset),
+    };
+  }
+
+  return null;
+}
+
 function isCompanyNameCandidate(line) {
   const text = collapseWhitespace(line);
   if (!text || text.length > 90) {
@@ -238,6 +305,71 @@ function scoreCompanyNameCandidate(text, lineIndex, lineCount, role) {
   }
 
   return score;
+}
+
+function collectImplicitDocumentNumberCandidates(lines) {
+  const candidates = [];
+  const topWindow = Math.min(lines.length, 6);
+
+  for (let index = 0; index < topWindow; index += 1) {
+    const text = collapseWhitespace(lines[index]);
+    if (!text || /\b(?:invoice|voucher|bill|ack|gst|date)\b/i.test(text)) {
+      continue;
+    }
+
+    const match = text.match(DOCUMENT_NUMBER_HASH_PATTERN);
+    if (!match) {
+      continue;
+    }
+
+    const normalizedValue = normalizeDocumentNumberValue(match[1]);
+    if (!/^[A-Z0-9][A-Z0-9/-]{0,39}$/i.test(normalizedValue)) {
+      continue;
+    }
+
+    candidates.push(
+      createCandidate("document.number", normalizedValue, {
+        normalizedValue,
+        displayValue: match[0].replace(/\s+/g, ""),
+        score: 43 - index,
+        source: "implicit_header",
+        lineIndex: index,
+        lineText: text,
+        reason: "matched top-header document number token",
+      }),
+    );
+  }
+
+  return candidates;
+}
+
+function collectImplicitDateCandidates(lines) {
+  const candidates = [];
+  const topWindow = Math.min(lines.length, 6);
+
+  for (let index = 0; index < topWindow; index += 1) {
+    const text = collapseWhitespace(lines[index]);
+    if (!text) {
+      continue;
+    }
+
+    const inlineDate = extractInlineDate(text);
+    if (!inlineDate) {
+      continue;
+    }
+
+    candidates.push(
+      createCandidate("document.date", inlineDate, {
+        score: 42 - index,
+        source: "implicit_header",
+        lineIndex: index,
+        lineText: text,
+        reason: "matched top-header inline date",
+      }),
+    );
+  }
+
+  return candidates;
 }
 
 function collectLabeledValueCandidates(lines, labelPatterns, validator, options = {}) {
@@ -317,6 +449,7 @@ function scoreVoucherFamily(lines, text, voucherFamily) {
   const hasDebitAndCredit = /\bdebit\b/i.test(text) && /\bcredit\b/i.test(text);
   const hasBalanceCue = STATEMENT_BALANCE_PATTERN.test(text);
   const statementColumnMatches = countPatternMatches(text, STATEMENT_COLUMN_PATTERN);
+  const gstinMatchCount = countPatternMatches(text, GSTIN_PATTERN);
 
   switch (voucherFamily) {
     case "proforma_invoice":
@@ -340,7 +473,13 @@ function scoreVoucherFamily(lines, text, voucherFamily) {
         score += 12;
         reasons.push("contains invoice header");
       }
-      if (/\b(?:GSTIN|IGST|CGST|SGST|amount payable|place of supply)\b/i.test(text)) {
+      if (
+        /\b(?:GSTIN|IGST|CGST|SGST|amount payable|place of supply|final amount|net amount|client|customer)\b/i.test(
+          text,
+        ) ||
+        /^Supply\s*:/im.test(text) ||
+        gstinMatchCount >= 2
+      ) {
         score += 4;
         reasons.push("contains invoice/GST field cues");
       }
@@ -685,6 +824,7 @@ function addDocumentCandidates(candidateMap, lines, text) {
       }),
     ),
   );
+  pushCandidates(candidateMap, "document.number", collectImplicitDocumentNumberCandidates(lines));
 
   pushCandidates(
     candidateMap,
@@ -704,6 +844,7 @@ function addDocumentCandidates(candidateMap, lines, text) {
       }),
     ),
   );
+  pushCandidates(candidateMap, "document.date", collectImplicitDateCandidates(lines));
 
   pushCandidates(
     candidateMap,
@@ -748,7 +889,7 @@ function addDocumentCandidates(candidateMap, lines, text) {
     "document.place_of_supply",
     collectLabeledValueCandidates(
       lines,
-      [/Place of Supply/i, /State Name/i],
+      [/Place of Supply/i, /^Supply\s*:/i, /State Name/i],
       (value) => /^[A-Za-z][A-Za-z\s().-]{1,60}$/.test(value),
       { inlineScore: 48, projectedScore: 40 },
     ).map((candidate) =>
@@ -860,6 +1001,21 @@ function addPartyCandidates(candidateMap, lines) {
           reason: role ? `GSTIN near ${assignedRole} section` : "GSTIN assigned by top-to-bottom fallback",
         }),
       );
+
+      const nearbyName = findNearbyPartyName(lines, index);
+      if (nearbyName) {
+        pushCandidate(
+          candidateMap,
+          `${assignedRole}.name`,
+          createCandidate(`${assignedRole}.name`, nearbyName.text, {
+            score: 42 - Math.min(nearbyName.distance, 2),
+            source: "party_proximity",
+            lineIndex: nearbyName.lineIndex,
+            lineText: nearbyName.text,
+            reason: `nearest name around ${assignedRole} GSTIN`,
+          }),
+        );
+      }
     }
   }
 }
@@ -881,6 +1037,9 @@ function scoreCueAmountCandidate(candidate, cuePattern, options = {}) {
   if (candidate.pageRightBucket === "edge" || candidate.pageRightBucket === "far_right") {
     score += 2;
   }
+  if (candidate.pageBottomBucket === "bottom") {
+    score += 2;
+  }
   if (candidate.lineItemCue) {
     score -= 5;
   }
@@ -888,9 +1047,133 @@ function scoreCueAmountCandidate(candidate, cuePattern, options = {}) {
   return score;
 }
 
+function bucketPageRight(ratio) {
+  if (!Number.isFinite(ratio)) {
+    return "unknown";
+  }
+  if (ratio >= 0.95) {
+    return "edge";
+  }
+  if (ratio >= 0.86) {
+    return "far_right";
+  }
+  if (ratio >= 0.72) {
+    return "right";
+  }
+  if (ratio >= 0.45) {
+    return "mid";
+  }
+  return "left";
+}
+
+function bucketPageBottom(ratio) {
+  if (!Number.isFinite(ratio)) {
+    return "unknown";
+  }
+  if (ratio >= 0.82) {
+    return "bottom";
+  }
+  if (ratio >= 0.55) {
+    return "mid";
+  }
+  return "top";
+}
+
+function isLikelyLineItemAmountRow(words, lineText) {
+  const numericWordCount = words.filter((word) => parseLooseMoneyToCents(word.text) != null).length;
+  const hasAlphaWord = words.some((word) => /[A-Za-z]{2}/.test(word.text ?? ""));
+  if (TABLE_LINE_CUE_PATTERN.test(lineText)) {
+    return true;
+  }
+  return numericWordCount >= 3 && hasAlphaWord;
+}
+
+function extractLooseAmountCandidates(source) {
+  const normalizedSource = normalizeTallySource(source);
+  const candidates = [];
+
+  for (const row of normalizedSource.rows) {
+    const sortedWords = [...(row.words ?? [])].sort((left, right) => (left.xMin ?? 0) - (right.xMin ?? 0));
+    const lineText = collapseWhitespace(row.text ?? "");
+    if (!lineText) {
+      continue;
+    }
+
+    const lineItemCue = isLikelyLineItemAmountRow(sortedWords, lineText);
+    for (let wordIndex = 0; wordIndex < sortedWords.length; wordIndex += 1) {
+      const word = sortedWords[wordIndex];
+      const rawText = String(word.text ?? "").trim();
+      if (!rawText || rawText.includes("/") || rawText.endsWith("%")) {
+        continue;
+      }
+      if (!LOOSE_MONEY_TOKEN_PATTERN.test(rawText)) {
+        continue;
+      }
+
+      const amountCents = parseLooseMoneyToCents(rawText);
+      if (amountCents == null) {
+        continue;
+      }
+
+      const leftWords = sortedWords.slice(0, wordIndex).map((entry) => entry.text ?? "");
+      const rightWords = sortedWords.slice(wordIndex + 1).map((entry) => entry.text ?? "");
+      const amountRightRatio =
+        typeof word.xMax === "number" && typeof row.pageWidth === "number" && row.pageWidth > 0
+          ? word.xMax / row.pageWidth
+          : null;
+      const pageBottomRatio =
+        typeof row.yMax === "number" && typeof row.pageHeight === "number" && row.pageHeight > 0
+          ? row.yMax / row.pageHeight
+          : (row.rowIndex + 1) / Math.max(normalizedSource.rows.length, 1);
+
+      candidates.push({
+        amountText: rawText,
+        amountCents,
+        lineIndex: row.rowIndex ?? null,
+        lineText,
+        leftText: collapseWhitespace(leftWords.join(" ")),
+        rightText: collapseWhitespace(rightWords.join(" ")),
+        amountIsRightmostWord: wordIndex === sortedWords.length - 1,
+        pageRightBucket: bucketPageRight(amountRightRatio),
+        pageBottomBucket: bucketPageBottom(pageBottomRatio),
+        lineItemCue,
+      });
+    }
+  }
+
+  return candidates;
+}
+
+function mergeAmountCandidates(...groups) {
+  const merged = new Map();
+
+  for (const group of groups) {
+    for (const candidate of group ?? []) {
+      const key = [candidate.lineIndex ?? -1, candidate.amountCents ?? -1, candidate.amountText ?? ""].join(":");
+      const previous = merged.get(key);
+      if (!previous) {
+        merged.set(key, candidate);
+        continue;
+      }
+
+      const previousSignals = [previous.leftText, previous.pageRightBucket, previous.pageBottomBucket].filter(Boolean)
+        .length;
+      const nextSignals = [candidate.leftText, candidate.pageRightBucket, candidate.pageBottomBucket].filter(Boolean)
+        .length;
+
+      if (nextSignals > previousSignals) {
+        merged.set(key, { ...previous, ...candidate });
+      }
+    }
+  }
+
+  return [...merged.values()];
+}
+
 function addAmountCandidates(candidateMap, source) {
   let amountCandidates = [];
   let rankedTotalCandidates = [];
+  let looseAmountCandidates = [];
 
   try {
     amountCandidates = extractReceiptAmountCandidates(source);
@@ -903,6 +1186,14 @@ function addAmountCandidates(candidateMap, source) {
   } catch {
     rankedTotalCandidates = [];
   }
+
+  try {
+    looseAmountCandidates = extractLooseAmountCandidates(source);
+  } catch {
+    looseAmountCandidates = [];
+  }
+
+  const combinedAmountCandidates = mergeAmountCandidates(amountCandidates, looseAmountCandidates);
 
   for (const candidate of rankedTotalCandidates.slice(0, 6)) {
     pushCandidate(
@@ -920,17 +1211,18 @@ function addAmountCandidates(candidateMap, source) {
     );
   }
 
-  for (const candidate of amountCandidates) {
+  for (const candidate of combinedAmountCandidates) {
     const lineText = candidate.lineText ?? "";
+    const leftText = candidate.leftText ?? "";
 
-    if (/\btaxable\b/i.test(lineText) || /\btaxable\b/i.test(candidate.leftText ?? "")) {
+    if (TAXABLE_CUE_PATTERN.test(lineText) || TAXABLE_CUE_PATTERN.test(leftText)) {
       pushCandidate(
         candidateMap,
         "amounts.taxable_amount_cents",
         createCandidate("amounts.taxable_amount_cents", candidate.amountCents, {
           normalizedValue: candidate.amountCents,
           displayValue: candidate.amountText,
-          score: scoreCueAmountCandidate(candidate, /\btaxable\b/i, { baseScore: 52 }),
+          score: scoreCueAmountCandidate(candidate, TAXABLE_CUE_PATTERN, { baseScore: 52 }),
           source: "amount_cue",
           lineIndex: candidate.lineIndex,
           lineText: candidate.lineText,
@@ -939,14 +1231,14 @@ function addAmountCandidates(candidateMap, source) {
       );
     }
 
-    if (/\bsub\s*total\b/i.test(lineText) || /\bsub\s*total\b/i.test(candidate.leftText ?? "")) {
+    if (SUBTOTAL_CUE_PATTERN.test(lineText) || SUBTOTAL_CUE_PATTERN.test(leftText)) {
       pushCandidate(
         candidateMap,
         "amounts.subtotal_cents",
         createCandidate("amounts.subtotal_cents", candidate.amountCents, {
           normalizedValue: candidate.amountCents,
           displayValue: candidate.amountText,
-          score: scoreCueAmountCandidate(candidate, /\bsub\s*total\b/i, { baseScore: 48 }),
+          score: scoreCueAmountCandidate(candidate, SUBTOTAL_CUE_PATTERN, { baseScore: 48 }),
           source: "amount_cue",
           lineIndex: candidate.lineIndex,
           lineText: candidate.lineText,
@@ -955,14 +1247,14 @@ function addAmountCandidates(candidateMap, source) {
       );
     }
 
-    if (/\b(?:discount|disc\.?)\b/i.test(lineText)) {
+    if (DISCOUNT_CUE_PATTERN.test(lineText)) {
       pushCandidate(
         candidateMap,
         "amounts.discount_cents",
         createCandidate("amounts.discount_cents", candidate.amountCents, {
           normalizedValue: candidate.amountCents,
           displayValue: candidate.amountText,
-          score: scoreCueAmountCandidate(candidate, /\b(?:discount|disc\.?)\b/i, { baseScore: 46 }),
+          score: scoreCueAmountCandidate(candidate, DISCOUNT_CUE_PATTERN, { baseScore: 46 }),
           source: "amount_cue",
           lineIndex: candidate.lineIndex,
           lineText: candidate.lineText,
@@ -971,18 +1263,53 @@ function addAmountCandidates(candidateMap, source) {
       );
     }
 
-    if (/\bround\s*off\b/i.test(lineText)) {
+    if (ROUND_OFF_CUE_PATTERN.test(lineText)) {
       pushCandidate(
         candidateMap,
         "amounts.round_off_cents",
         createCandidate("amounts.round_off_cents", candidate.amountCents, {
           normalizedValue: candidate.amountCents,
           displayValue: candidate.amountText,
-          score: scoreCueAmountCandidate(candidate, /\bround\s*off\b/i, { baseScore: 46 }),
+          score: scoreCueAmountCandidate(candidate, ROUND_OFF_CUE_PATTERN, { baseScore: 46 }),
           source: "amount_cue",
           lineIndex: candidate.lineIndex,
           lineText: candidate.lineText,
           reason: "matched round-off cue",
+        }),
+      );
+    }
+
+    if (GRAND_TOTAL_CUE_PATTERN.test(lineText) || GRAND_TOTAL_CUE_PATTERN.test(leftText)) {
+      pushCandidate(
+        candidateMap,
+        "amounts.grand_total_cents",
+        createCandidate("amounts.grand_total_cents", candidate.amountCents, {
+          normalizedValue: candidate.amountCents,
+          displayValue: candidate.amountText,
+          score: scoreCueAmountCandidate(candidate, GRAND_TOTAL_CUE_PATTERN, { baseScore: 58 }),
+          source: "amount_cue",
+          lineIndex: candidate.lineIndex,
+          lineText: candidate.lineText,
+          reason: "matched grand-total cue",
+        }),
+      );
+    } else if (
+      !candidate.lineItemCue &&
+      candidate.amountCents >= 100000 &&
+      candidate.amountIsRightmostWord &&
+      (candidate.pageBottomBucket === "bottom" || candidate.pageRightBucket === "edge")
+    ) {
+      pushCandidate(
+        candidateMap,
+        "amounts.grand_total_cents",
+        createCandidate("amounts.grand_total_cents", candidate.amountCents, {
+          normalizedValue: candidate.amountCents,
+          displayValue: candidate.amountText,
+          score: scoreCueAmountCandidate(candidate, GRAND_TOTAL_CUE_PATTERN, { baseScore: 30 }),
+          source: "weak_amount_fallback",
+          lineIndex: candidate.lineIndex,
+          lineText: candidate.lineText,
+          reason: "unlabeled bottom/right amount candidate",
         }),
       );
     }
@@ -1047,6 +1374,26 @@ function addAmountCandidates(candidateMap, source) {
           lineIndex: candidate.lineIndex,
           lineText: candidate.lineText,
           reason: "matched CESS cue",
+        }),
+      );
+    }
+
+    if (
+      TAX_LINE_CUE_PATTERN.test(lineText) &&
+      !/\b(?:igst|cgst|sgst|cess)\b/i.test(lineText) &&
+      !candidate.lineItemCue
+    ) {
+      pushCandidate(
+        candidateMap,
+        "amounts.taxable_amount_cents",
+        createCandidate("amounts.taxable_amount_cents", candidate.amountCents, {
+          normalizedValue: candidate.amountCents,
+          displayValue: candidate.amountText,
+          score: scoreCueAmountCandidate(candidate, TAX_LINE_CUE_PATTERN, { baseScore: 22 }),
+          source: "weak_tax_fallback",
+          lineIndex: candidate.lineIndex,
+          lineText: candidate.lineText,
+          reason: "generic tax line amount",
         }),
       );
     }

--- a/tally/psvm.test.mjs
+++ b/tally/psvm.test.mjs
@@ -64,6 +64,26 @@ Date Narration Debit Credit Balance
 04/01/2026 Closing Balance 33,750.00
 `;
 
+const IMPLICIT_FIELD_SAMPLE = `
+#7782      11/07/25
+
+KAPOOR & SONS
+24ABCDE1111F1Z3
+
+Client:
+R K ENTERPRISES
+24AAAAA2222G1Z4
+
+Supply: Gujarat
+
+Item        Qty   Price   Total
+Tiles       200   50      10000
+
+Tax 18%              1800
+
+Final Amount         11800
+`;
+
 test("voucher classifier prefers proforma over generic invoice families", () => {
   const classification = classifyTallyVoucherFamily(PROFORMA_SAMPLE);
   assert.equal(classification.selectedFamily.voucherFamily, "proforma_invoice");
@@ -117,4 +137,26 @@ test("statement-like OCR is classified as unsupported instead of guessed as an i
   assert.match(result.result.rejectionReason, /ledger-oriented PSVM/i);
   assert.equal(result.result.amounts.grandTotalCents, null);
   assert.ok(!("document.number" in result.state.fieldCandidates));
+});
+
+test("tally PSVM surfaces implicit header fields and weak-label totals", () => {
+  const state = buildTallyExtractionState(IMPLICIT_FIELD_SAMPLE);
+  assert.equal(state.voucherFamily, "sales_invoice");
+  assert.equal(state.selectedFields["document.number"], "7782");
+  assert.equal(state.selectedFields["document.date"], "11/07/25");
+  assert.equal(state.selectedFields["document.place_of_supply"], "Gujarat");
+  assert.equal(state.selectedFields["seller.name"], "KAPOOR & SONS");
+  assert.equal(state.selectedFields["buyer.name"], "R K ENTERPRISES");
+  assert.equal(state.selectedFields["amounts.grand_total_cents"], 1180000);
+
+  const result = runTallyExtractionPsvm(IMPLICIT_FIELD_SAMPLE);
+  assert.equal(result.result.document.number, "7782");
+  assert.equal(result.result.document.date, "11/07/25");
+  assert.equal(result.result.seller.gstin, "24ABCDE1111F1Z3");
+  assert.equal(result.result.buyer.gstin, "24AAAAA2222G1Z4");
+  assert.equal(result.result.amounts.grandTotalCents, 1180000);
+  assert.equal(result.result.lineItems[0].description, "Tiles");
+  assert.equal(result.result.lineItems[0].quantity, 200);
+  assert.equal(result.result.lineItems[0].unitPriceCents, 5000);
+  assert.equal(result.result.lineItems[0].amountCents, 1000000);
 });

--- a/tally/table_parser.mjs
+++ b/tally/table_parser.mjs
@@ -1,12 +1,12 @@
 import { buildPlainTextReceiptSource, collapseWhitespace } from "../invoice/ocr_layout.mjs";
 
-const MONEY_TOKEN_PATTERN = /(?:₹\s*)?(?:Rs\.?\s*)?[0-9][0-9,]*\.\d{2}/i;
-const MONEY_TOKEN_GLOBAL_PATTERN = /(?:₹\s*)?(?:Rs\.?\s*)?[0-9][0-9,]*\.\d{2}/g;
+const MONEY_TOKEN_PATTERN = /(?:₹\s*)?(?:Rs\.?\s*)?[0-9][0-9,]*(?:\.\d{1,2})?/i;
+const MONEY_TOKEN_GLOBAL_PATTERN = /(?:₹\s*)?(?:Rs\.?\s*)?[0-9][0-9,]*(?:\.\d{1,2})?/g;
 const LEADING_SERIAL_PATTERN = /^\s*(\d{1,4})(?:[.)-]|\s+)/;
 const HEADER_TOKEN_LIMIT = 64;
 const HEADER_SCORE_THRESHOLD = 8;
 const FOOTER_LEAD_PATTERN =
-  /^(?:taxable|sub\s*total|grand\s*total|total(?:\s+amount)?|amount\s+(?:due|payable)|round\s*off|roundoff|igst|cgst|sgst|cess|tcs|rupees|inr|bank|declaration|terms|payment\s+term|e&oe|authorised|authorized)/i;
+  /^(?:taxable|sub\s*total|grand\s*total|final amount|net amount|net payable|total(?:\s+amount)?|amount\s+(?:due|payable)|round\s*off|roundoff|tax(?:\s+\d+(?:\.\d+)?%)?|igst|cgst|sgst|cess|tcs|rupees|inr|bank|declaration|terms|payment\s+term|e&oe|authorised|authorized)/i;
 const HEADER_REPEAT_PATTERN =
   /\b(?:description|product|goods|item|particulars)\b/i;
 
@@ -69,6 +69,15 @@ function parseMoneyToCents(value) {
   return Number(whole) * 100 + Number(fraction.padEnd(2, "0"));
 }
 
+function looksLikeMoneyToken(value) {
+  const text = String(value ?? "").trim();
+  if (!text) {
+    return false;
+  }
+
+  return /₹|Rs\.?/i.test(text) || (/\d/.test(text) && (text.includes(",") || text.includes(".") || /^\d{4,}$/.test(text)));
+}
+
 function extractHsnValue(value) {
   const match = collapseWhitespace(String(value ?? "")).match(/\b\d{4,8}\b/);
   return match?.[0] ?? null;
@@ -102,6 +111,9 @@ function extractLeadingSerialText(text) {
 function extractMoneyTokens(words) {
   return sortWords(words)
     .map((word, index) => {
+      if (!looksLikeMoneyToken(word.text)) {
+        return null;
+      }
       const amountCents = parseMoneyToCents(word.text);
       if (amountCents == null) {
         return null;
@@ -226,7 +238,7 @@ function collectHeaderAnchors(rows) {
       if (cleaned === "rate" || cleaned === "price" || cleaned === "value") {
         ratePositions.push(x);
       }
-      if (cleaned === "amount" || cleaned === "amt" || cleaned === "gross") {
+      if (cleaned === "amount" || cleaned === "amt" || cleaned === "gross" || cleaned === "total") {
         amountPositions.push(x);
       }
       if (cleaned === "mrp") {
@@ -577,6 +589,30 @@ function extractFallbackQuantity(sortedWords, serialIndex, hsnIndex, firstMoneyI
   };
 }
 
+function findWordIndexInColumn(sortedWords, column, matcher) {
+  if (!column) {
+    return null;
+  }
+
+  for (let index = 0; index < sortedWords.length; index += 1) {
+    const word = sortedWords[index];
+    const x = wordCenterX(word);
+    if (column.left != null && x < column.left) {
+      continue;
+    }
+    if (column.right != null && x >= column.right) {
+      continue;
+    }
+
+    const cleaned = cleanToken(word.text ?? "");
+    if (matcher(cleaned)) {
+      return index;
+    }
+  }
+
+  return null;
+}
+
 function parseItemRow(row, header, currentItem) {
   const rowText = collapseWhitespace(row.text ?? "");
   if (!rowText) {
@@ -606,7 +642,13 @@ function parseItemRow(row, header, currentItem) {
     amountToken?.index ?? null,
     excludedHsnValues,
   );
+  const quantityColumn = header.columns.find((column) => column.key === "quantity");
   const quantityFromCell = parseQuantityWithUnit(cells.quantity, header.defaultUnit);
+  const quantityCellIndex = findWordIndexInColumn(
+    sortedWords,
+    quantityColumn,
+    (cleaned) => parseDecimalValue(cleaned) != null,
+  );
   const fallbackQuantity = extractFallbackQuantity(
     sortedWords,
     leadingSerial != null ? 0 : null,
@@ -623,7 +665,7 @@ function parseItemRow(row, header, currentItem) {
       hasLeadingSerial: leadingSerial != null,
       hsnIndex: hsnToken?.index ?? null,
       percentIndex: percentTokens[0]?.index ?? null,
-      quantityIndex: fallbackQuantity.index ?? null,
+      quantityIndex: quantityCellIndex ?? fallbackQuantity.index ?? null,
       unitPriceIndex: unitPriceToken?.index ?? null,
       amountIndex: amountToken?.index ?? null,
     }) ||
@@ -668,7 +710,7 @@ function parseItemRow(row, header, currentItem) {
   if (!hasNewItemSignal) {
     const continuationText = collapseWhitespace(
       sortedWords
-        .filter((word) => !MONEY_TOKEN_PATTERN.test(word.text))
+        .filter((word) => !looksLikeMoneyToken(word.text))
         .map((word) => word.text)
         .join(" "),
     );


### PR DESCRIPTION
## Summary
- improve Tally weak-label and implicit-header parsing for fields like `Client`, `Supply:`, `Final Amount`, and `#7782`
- add integer-amount fallback plus tighter compact-row table parsing for simple line items
- add `implicit_field` harness coverage, tests, and seed data for future retraining

## Verification
- node --test invoice/receipt.test.mjs invoice/total_psvm.test.mjs tally/psvm.test.mjs tally/table_parser.test.mjs tally/harness.test.mjs tally/model.test.mjs tally/schema.test.mjs
- node scripts/evaluate_tally_harness.mjs